### PR TITLE
feat: Add `snark-bn254-verifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,20 @@ name = "bytemuck"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "byteorder"
@@ -4672,6 +4686,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "lazycell"
@@ -6621,6 +6638,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "snark-bn254-verifier",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -9427,6 +9445,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "snark-bn254-verifier"
+version = "1.0.2"
+source = "git+https://github.com/succinctlabs/snark-bn254-verifier#439f86c538a2d473ca3812debfe4abd47d490ba3"
+dependencies = [
+ "rand",
+ "sha2 0.10.8",
+ "substrate-bn",
+ "thiserror-no-std",
+]
+
+[[package]]
 name = "snow"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9441,6 +9470,16 @@ dependencies = [
  "rustc_version 0.4.1",
  "sha2 0.10.8",
  "subtle 2.6.1",
+]
+
+[[package]]
+name = "snowbridge-amcl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460a9ed63cdf03c1b9847e8a12a5f5ba19c4efd5869e4a737e05be25d7c427e5"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -10247,6 +10286,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-lib"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea7811abd2d3a991007fcb284f41152840b8388c171288d0c52c6793956609c"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "hex",
+ "serde",
+ "snowbridge-amcl",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10414,6 +10467,22 @@ dependencies = [
  "schnorrkel",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.7.0"
+source = "git+https://github.com/sp1-patches/bn?branch=patch-v0.7.0#3c53d2561492f26b9428c1d37d134031d0156152"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint",
+ "rand",
+ "rustc-hex",
+ "sp1-lib",
 ]
 
 [[package]]

--- a/pallets/vector/Cargo.toml
+++ b/pallets/vector/Cargo.toml
@@ -8,11 +8,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 frame-system = { workspace = true, default-features = false }
-avail-core = { workspace = true, default-features = false, features = ["runtime"]}
+avail-core = { workspace = true, default-features = false, features = [
+	"runtime",
+] }
 avail-base = { workspace = true, default-features = false }
 patricia-merkle-trie = { workspace = true, default-features = false }
 
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+	"derive",
+] }
 scale-info.workspace = true
 frame-support = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
@@ -35,12 +39,16 @@ primitive-types.workspace = true
 ethabi.workspace = true
 
 
+snark-bn254-verifier = { git = "https://github.com/succinctlabs/snark-bn254-verifier" }
+
 [dev-dependencies]
-pallet-balances = { workspace = true, default-features = false, features = ["std"] }
+pallet-balances = { workspace = true, default-features = false, features = [
+	"std",
+] }
 pallet-timestamp = { workspace = true, default-features = false }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
 	"avail-base/std",
 	"avail-core/std",


### PR DESCRIPTION
Confirmed https://github.com/succinctlabs/snark-bn254-verifier compiles with `cargo build -p avail-node` in the root.

